### PR TITLE
Make model association step more idiomatic

### DIFF
--- a/src/models/index.js
+++ b/src/models/index.js
@@ -21,11 +21,12 @@ const models = {
   Message: sequelize.import('./message'),
 };
 
-Object.keys(models).forEach(key => {
-  if ('associate' in models[key]) {
-    models[key].associate(models);
-  }
-});
+Object.values(models)
+  .forEach(model => {
+    if (model.associate) {
+      model.associate(models);
+    }
+  });
 
 export { sequelize };
 


### PR DESCRIPTION
* use Object.values to get a more meaningful `model` var and associate it if it has an associate field.